### PR TITLE
fix: css

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # miniviz-docs
 
 Miniviz のドキュメントです。  
-本番: https://docs.miniviz.net/
+正規URL: https://miniviz.net/docs
 
-ソースは **`website/`** のみ（Docusaurus）。英語がデフォルト、日本語は **`/ja/`**。
+ソースは **`website/`** のみ（Docusaurus）。英語がデフォルト、日本語は **`/docs/ja/`**。
 
 ## 前提
 
@@ -17,8 +17,8 @@ npm install
 npm start
 ```
 
-- 英語: http://localhost:3000/
-- **このモードでは `http://localhost:3000/ja` はルートが無く 404 になります**（Docusaurus の開発サーバーは起動時に **1 ロケールだけ** 扱うため）。**英語と日本語を同じプロセスで開きたい場合は、下の `npm run preview` を使ってください。**
+- 英語: http://localhost:3000/docs/
+- **このモードでは `http://localhost:3000/docs/ja` はルートが無く 404 になります**（Docusaurus の開発サーバーは起動時に **1 ロケールだけ** 扱うため）。**英語と日本語を同じプロセスで開きたい場合は、下の `npm run preview` を使ってください。**
 
 ## 開発（日本語だけ見る）
 
@@ -27,18 +27,18 @@ cd website
 npm run start:ja
 ```
 
-起動メッセージの URL（通常は **`http://localhost:3000/ja/`**）を開いてください。
+起動メッセージの URL（通常は **`http://localhost:3000/docs/ja/`**）を開いてください。
 
 ## 本番に近いローカル起動（`npm run preview`）
 
-`docusaurus build` のあと `docusaurus serve` で静的成果物を配信します。**デフォルトの英語（`/`）と日本語（`/ja/`）が同時に使える**ので、Vercel 本番に近い確認向きです。
+`docusaurus build` のあと `docusaurus serve` で静的成果物を配信します。**デフォルトの英語（`/docs/`）と日本語（`/docs/ja/`）が同時に使える**ので、Vercel 本番に近い確認向きです。
 
 ```bash
 cd website
 npm run preview
 ```
 
-ターミナルに表示される URL（通常 **`http://localhost:3000/`**）を開き、`/` と `/ja/` を切り替えてください。
+ターミナルに表示される URL（通常 **`http://localhost:3000/docs/`**）を開き、`/docs/` と `/docs/ja/` を切り替えてください。
 
 ## 本番ビルドのみ
 
@@ -52,7 +52,9 @@ npm run serve
 
 プロジェクトの **Root Directory** を **`website`** に指定。`website/vercel.json` 参照（`buildCommand`: `npm run build`、`outputDirectory`: `build`）。
 
-**多言語（i18n）について:** このままデプロイして問題ありません。`npm run build` の出力は **英語が `build/` 配下のルート**、**日本語が `build/ja/`** という静的ファイル構成になり、Vercel の静的ホスティングでそのまま配信されます。追加のリライトやエッジ設定は不要です（ドキュメント URL は `https://example.com/quickstart` と `https://example.com/ja/quickstart` のような形）。
+`docusaurus build` の静的成果物は `build/` 直下に出力されますが、`website/vercel.json` で **`/docs/* -> /*`** の rewrite を入れ、`/docs` 配下として配信できるようにしています。
+
+**多言語（i18n）について:** ビルド成果物そのものは **英語が `build/` ルート**、**日本語が `build/ja/`** ですが、公開URLは `https://miniviz.net/docs/...` と `https://miniviz.net/docs/ja/...` を正規形として扱います。
 
 ## 画像
 

--- a/task.md
+++ b/task.md
@@ -6,10 +6,12 @@
 
 - [x] Docusaurus、`en` / `ja`、画像は `website/static/images` + `/images/...`
 - [x] Jekyll（`docs/`、Gemfile、`.github/workflows/deploy.yml`）削除
+- [x] `baseUrl: '/docs/'` と Vercel rewrite で `/docs` 配信に対応
 
 ## 残タスク（任意）
 
-- [ ] Vercel 本番・`docs.miniviz.net` の DNS
+- [ ] Vercel 本番で `miniviz.net/docs` を正規URLとして公開
+- [ ] `docs.miniviz.net/*` から `miniviz.net/docs/*` への `301` リダイレクトを設定
 - [ ] 壊れたアンカー修正（例: `ja/hardware/raspi_pico_1` 内の目次リンク）
 
 ## ローカル
@@ -20,4 +22,4 @@ cd website && npm install && npm start
 
 ## URL 互換
 
-旧 Jekyll のパス（例: `/en/quickstart`）と完全一致しない場合は、Vercel の `redirects`（`vercel.json`）でリダイレクトを列挙する。
+旧 Jekyll のパス（例: `/en/quickstart`）や旧 docs サブドメインのパスと完全一致しない場合は、Vercel の `redirects`（`vercel.json`）やドメイン設定側でリダイレクトを列挙する。

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -6,6 +6,20 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * 本番（miniviz.net/docs）では baseUrl を /docs/ に固定する。
+ * Vercel Preview（*.vercel.app 単体デプロイ）ではルート直下に置くため baseUrl は / にする。
+ * そうしないと HTML が /docs/assets/... を参照し、プレビューでは CSS が死んで 404 になりやすい。
+ */
+const vercelEnv = process.env.VERCEL_ENV;
+const vercelUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL.replace(/^https?:\/\//, '')}`
+  : undefined;
+const isVercelPreview = vercelEnv === 'preview' && Boolean(vercelUrl);
+
+const siteUrl = isVercelPreview ? vercelUrl! : 'https://miniviz.net';
+const baseUrl = isVercelPreview ? '/' : '/docs/';
+
 const config: Config = {
   title: 'Miniviz Docs',
   tagline: 'Documentation for Miniviz',
@@ -15,8 +29,8 @@ const config: Config = {
     v4: true,
   },
 
-  url: 'https://docs.miniviz.net',
-  baseUrl: '/',
+  url: siteUrl,
+  baseUrl,
 
   organizationName: 'miniviz',
   projectName: 'miniviz-docs',

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://docs.miniviz.net/sitemap.xml
+Sitemap: https://miniviz.net/docs/sitemap.xml

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,5 +1,15 @@
 {
   "installCommand": "npm install",
   "buildCommand": "npm run build",
-  "outputDirectory": "build"
+  "outputDirectory": "build",
+  "rewrites": [
+    {
+      "source": "/docs",
+      "destination": "/"
+    },
+    {
+      "source": "/docs/:path*",
+      "destination": "/:path*"
+    }
+  ]
 }


### PR DESCRIPTION
This pull request updates the documentation site to serve all content under the `/docs` path, aligning local development, production, and preview environments, and adjusts URLs, configuration, and deployment settings accordingly. The changes ensure that both English and Japanese documentation are accessible under `/docs/` and `/docs/ja/`, and that Vercel previews and production deployments work seamlessly with the new structure.

**URL and Path Updates:**

* Updated all documentation URLs in `README.md` and instructions to use `/docs/` and `/docs/ja/` as the base paths for English and Japanese content. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R21) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R41)
* Changed the canonical documentation URL to `https://miniviz.net/docs` and updated references throughout. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R6) [[2]](diffhunk://#diff-7cbced28171cc817ffcb00c301557664152b356b3b928cc7d866916d40a521c0L4-R4)

**Docusaurus and Deployment Configuration:**

* Modified `docusaurus.config.ts` to set `baseUrl` to `/docs/` for production and `/` for Vercel Preview deployments, ensuring correct asset paths and site URLs in all environments. [[1]](diffhunk://#diff-1de336ccbebeecf69018f0a9d5559e7f033215d5f0c399933cfd686186b5b0fbR9-R22) [[2]](diffhunk://#diff-1de336ccbebeecf69018f0a9d5559e7f033215d5f0c399933cfd686186b5b0fbL18-R33)
* Updated `vercel.json` to add rewrites so that `/docs` and `/docs/*` routes are served from the root build output, enabling `/docs` as the public path.

**Documentation and Task Tracking:**

* Added and clarified tasks in `task.md` to reflect the new `/docs` structure, including Vercel production deployment and redirection requirements. [[1]](diffhunk://#diff-80de932cadfdfae6ad9731e8f3bd3544fed09b0a70238a514b99d1d5929c6e64R9-R14) [[2]](diffhunk://#diff-80de932cadfdfae6ad9731e8f3bd3544fed09b0a70238a514b99d1d5929c6e64L23-R25)

**Additional Details:**

* Updated the sitemap URL in `robots.txt` to match the new canonical URL.
* Clarified how multilingual static files are mapped to public URLs, and explained the effect of rewrites on deployment.